### PR TITLE
Updated to include a check for macOS 10.12.6

### DIFF
--- a/Extension Attributes/Automated_Device_Enrollment_ConfigurationURL.EA.sh
+++ b/Extension Attributes/Automated_Device_Enrollment_ConfigurationURL.EA.sh
@@ -44,12 +44,37 @@
 #
 # ----------------------------------------------------------------------------------------------------------------------------
 # Requirements:
-# - v10.12.6 of profiles binary or later
+# - macOS 10.12.6 or later
 # - Technically, you'd need Jamf Pro to report as an EA.  However, the script will still run on a non-Jamf Pro managed Mac, 
 #  it's output though was designed for use as Extension Attribute.
 # 
 #
 # ----------------------------------------------------------------------------------------------------------------------------
+
+######################################################
+# Ensure we're running macOS 10.12.6 or later
+
+# Get the macOS version
+os_version=$(sw_vers -productVersion)
+
+# Split the version into its components
+IFS='.' read -r major minor patch <<< "$os_version"
+
+# Set the minimum required version components
+min_major=10
+min_minor=12
+min_patch=6
+
+# Compare the version components
+if (( major > min_major )) || 
+   (( major == min_major && minor > min_minor )) || 
+   (( major == min_major && minor == min_minor && patch >= min_patch )); then
+    echo "macOS version is sufficient: $os_version"
+else
+    echo "macOS 10.12.6 or later required"
+    echo "<result>macOS 10.12.6 or later required</result>"
+    exit 0
+fi
 
 ######################################################
 # Get the Automated Device Enrollment ConfigurationURL


### PR DESCRIPTION
### Pull Request Description

**Title: Update EA Script to Check for Minimum macOS Version 10.12.6**

**Description:**

This pull request updates the Extension Attribute (EA) script for collecting the Automated Device Enrollment Configuration URL. The script now includes a check to ensure that the macOS version is at least 10.12.6 before proceeding with the URL collection.

**Changes:**

1. **Automated Device Enrollment Configuration URL Collector**

    - **Script Name:** `Automated_Device_Enrollment_ConfigurationURL.EA.sh`
    - **Purpose:** This EA collects the Automated Device Enrollment Configuration URL from the target machine using the macOS native binary `profiles`.
    - **Update:**
        - Added a check to ensure the macOS version is at least 10.12.6.
        - The script now splits the macOS version into major, minor, and patch components and performs a detailed comparison to ensure compliance.

**How to Test:**

1. **Automated Device Enrollment Configuration URL Collector:**
    - Deploy the updated script to a macOS device.
    - Verify that the script correctly checks the macOS version.
    - If the macOS version is less than 10.12.6, the script should output: `<result>macOS 10.12.6 or later required</result>`.
    - If the macOS version is 10.12.6 or later, the script should proceed to collect the `ConfigurationURL` and output the result.

**Note:**
This script is licensed under the Creative Commons Attribution-NonCommercial 4.0 International License.

**Reviewers:**
Please review the updated script for accuracy, efficiency, and compliance with our coding standards. Any feedback or suggestions for improvement are welcome.

---

For any questions or further clarifications, feel free to reach out.